### PR TITLE
dts: j3s: set minimum refresh rate to 60hz & remove 30hz

### DIFF
--- a/arch/arm64/boot/dts/vendor/qcom/dsi-panel-j3s-37-02-0a-dsc-video.dtsi
+++ b/arch/arm64/boot/dts/vendor/qcom/dsi-panel-j3s-37-02-0a-dsc-video.dtsi
@@ -52,11 +52,11 @@
 			17000 15500 30000 8000 3000>;
 		qcom,mdss-dsi-panel-peak-brightness = <4200000>;
 		qcom,mdss-dsi-panel-blackness-level = <3230>;
-		qcom,mdss-dsi-qsync-min-refresh-rate = <30>;
+		qcom,mdss-dsi-qsync-min-refresh-rate = <60>;
 		qcom,mdss-dsi-pan-enable-dynamic-fps;
 		qcom,mdss-dsi-pan-fps-update =
 				"dfps_immediate_porch_mode_vfp";
-		qcom,dsi-supported-dfps-list = <144 120 90 60 30>;
+		qcom,dsi-supported-dfps-list = <144 120 90 60>;
 
 		qcom,mdss-dsi-display-timings {
 			timing@0{


### PR DESCRIPTION
30hz causes instability in adaptive refresh rates and 60hz is our lowest native refresh rate